### PR TITLE
Invert result

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 Annotate Root Item Path
 =======================
 
-![Last tested in Nuix 7.4](https://img.shields.io/badge/Nuix-7.4-green.svg)
+![Last tested in Nuix 9.6](https://img.shields.io/badge/Nuix-9.6-green.svg)
 
 View the GitHub project [here](https://github.com/Nuix/Annotate-Root-Item-Path) or download the latest release [here](https://github.com/Nuix/Annotate-Root-Item-Path/releases).
 
@@ -10,25 +10,21 @@ View the GitHub project [here](https://github.com/Nuix/Annotate-Root-Item-Path) 
 
 **Written By:** Jason Wells
 
-This script will iterate either all items in the case or the currently selected items, annotating an item path containing the top N items each item, optionally including the evidence container's name.
+This script will iterate either all items in the case or the currently selected items, annotating a concatenation of a subset of each item's path items names, optionally including the evidence container's name.
 
 For example, imagine your case has an attachment to an email with the following item path:
 
 ```
-Evidence 1/MailBox.pst/Top of Personal Folders/Inbox/Email/Attachment
+Evidence 1/MailBox.pst/Top of Personal Folders/Inbox/Email/Attachment/EmbeddedImage
 ```
 
-With a depth setting of 3, with **Include Evidence Container** checked, the following would be recorded on the item:
+Here are the different values that could be recorded, depending on the settings you choose.
 
-```
-Evidence 1/MailBox.pst/Top of Personal Folders
-```
-
-Without **Include Evidence Container** checked:
-
-```
-MailBox.pst/Top of Personal Folders/Inbox
-```
+| Depth | Include Evidence Container             | Invert Result           | Resulting Value                                  |
+|-------|----------------------------------------|-------------------------|--------------------------------------------------|
+| `3`   | :ballot_box_with_check:                | :black_square_button:   | `Evidence 1/MailBox.pst/Top of Personal Folders` |
+| `3`   | :black_square_button:                  | :black_square_button:   | `MailBox.pst/Top of Personal Folders/Inbox`      |
+| `3`   | Ignored when **Invert Result** Checked | :ballot_box_with_check: | `Inbox/Email/Attachment/EmbeddedImage`           |
 
 # Getting Started
 
@@ -46,11 +42,12 @@ Begin by downloading the latest release of this code.  Extract the contents of t
 | **Root Item Path Depth**       | How many items from the top of the item path to include.                               |
 | **Include Evidence Container** | When checked the evidence container item will be included in the calculated path value. |
 | **Custom Field Name**          | The name of the custom metadata field the value will be recorded to.                   |
+| **Invert Result**              | When checked, rather than keeping first N items' path names, value will instead be everything *but* the first N items' path names. |
 
 # License
 
 ```
-Copyright 2018 Nuix
+Copyright 2022 Nuix
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added setting to invert result.  Before if you chose a depth of 3, you get the first 3 path item names.  You'd get the first three after the evidence container if you did not choose to include the evidence container.  Now if you check **Invert Result** you will get everything *EXCEPT* the first 3 path item names.  **NOTE:** When using **Invert Result** the **Include Evidence Container** setting is ignore and has no effect.